### PR TITLE
Update the git clone repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 1. Clone repo
     ```
-    git clone https://github.com/sanity-io/sanity-nextjs-examle
+    git clone https://github.com/sanity-io/sanity-nextjs-vercel-example.git
     ```
 1. Install dependencies
     ```


### PR DESCRIPTION
Update the wrong repo link included in the first step.

```diff
- git clone https://github.com/sanity-io/sanity-nextjs-examle
+ git clone https://github.com/sanity-io/sanity-nextjs-vercel-example.git
```